### PR TITLE
Dockerize build and update secret.bin to pass boot validation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git/
+mijia-720p-hack.zip
+sdcard/mijia-720p-hack/bin/*
+src/*
+prefix/*
+image.tgz
+tf_recovery.img
+image.tgz
+image.tgz

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,3 @@ sdcard/mijia-720p-hack/bin/*
 src/*
 prefix/*
 image.tgz
-tf_recovery.img
-image.tgz
-image.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ sdcard/mijia-720p-hack/bin/*
 sdcard/manufacture.bin
 gm_lib/*
 !gm_lib/README
+image.tgz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+FROM ubuntu:18.04
+
+####################################################
+## Install dependencies and requirements          ##
+####################################################
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update                                                                                                 \
+ && apt-get install -y                                                                                             \
+      autoconf                                                                                                     \
+      build-essential                                                                                              \
+      curl                                                                                                         \
+      wget                                                                                                         \
+      git-core                                                                                                     \
+      lib32z1-dev                                                                                                  \
+      make                                                                                                         \
+      ncurses-dev                                                                                                  \
+      unrar                                                                                                        \
+      unzip                                                                                                        \
+ && apt-get clean
+
+
+####################################################
+## Download and unpack toolchain                  ##
+####################################################
+
+RUN curl --output /usr/src/toolchain.rar https://fliphess.com/GM8136_SDK_release_v1.0.rar                          \
+ && cd /usr/src                                                                                                    \
+ && unrar x toolchain.rar
+
+
+####################################################
+## Get repo                                       ##
+####################################################
+
+COPY . /build
+
+
+####################################################
+## Copy required toolchain parts to /usr/src      ##
+####################################################
+
+RUN true                                                                                                           \
+ && cd /usr/src                                                                                                    \
+ && echo "*** Unpacking Embedded Linux"                                                                            \
+ && tar xzf /usr/src/'GM8136 SDK release v1.0'/Software/Embedded_Linux/source/arm-linux-3.3_2015-01-09.tgz         \
+ && cd /usr/src/arm-linux-3.3                                                                                      \
+ && echo "*** Unpacking Toolchain"                                                                                 \
+ && tar xzf /usr/src/'GM8136 SDK release v1.0'/Software/Embedded_Linux/source/toolchain_gnueabi-4.4.0_ARMv5TE.tgz  \
+ && cd /build/gm_lib                                                                                               \
+ && echo "*** Unpacking GM Lib"                                                                                    \
+ && tar xzf /usr/src/'GM8136 SDK release v1.0'/Software/Embedded_Linux/source/gm_lib_2015-01-09-IPCAM.tgz
+
+
+####################################################
+## Setting workdir to /build                      ##
+####################################################
+
+WORKDIR /build
+

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+echo "Removing previous result if present"
+test -f result.tgz && rm result.tgz
+
+echo "Building docker container with toolchain and requirements"
+docker build -t mijia-720p-hack ${SCRIPTPATH} $@
+
+echo "Building mijia-720p-hack"
+docker run -i                  \
+    -v "${SCRIPTPATH}:/result" \
+    --detach=false             \
+    --tty=true                 \
+    --rm                       \
+    --dns "8.8.8.8"            \
+mijia-720p-hack /bin/bash -c 'make && make install && tar czf /result/image.tgz /build/sdcard'

--- a/sdcard/ft/secret.bin
+++ b/sdcard/ft/secret.bin
@@ -1,1 +1,2 @@
-hE2¹{c7sùÃŠ™®umäqàˆl«å<Ÿj	Èñÿ`¤kõƒÏÐa±šPÐÿ×-Ý¬6bÄ7Y°IXãÃ-á¸;ØQk§/€àEçúFæ[h+1óYK#3“ÝMxmÍBºÚZLUd,«w¶>£ÀŒ¸0SÊW¦
+‡¤Ò»Éi¦Ö†	[@üÞ?0Ÿ~+µæ×Ð¬6(>ÍØÝz!« ¨õãi#‰“ˆÁ©Qibà¬›‘ ,ÇÉôµ?è9
+ÙU95Qé£5Âövý?µ?µXâ0ŽÕ¦•û[G„ Ü<‰Ãü-¤ºßÜ—t	ƒb-4B+ynÃ

--- a/sdcard/mijia-720p-hack/scripts/S50disable_ota
+++ b/sdcard/mijia-720p-hack/scripts/S50disable_ota
@@ -22,7 +22,7 @@ disable_ota() {
 enable_ota() {
   if [ -f "${sd_mountdir}/mijia-720p-hack/scripts/.pre-ota.sh" ] &&
      ! mount | grep -q /mnt/data/miio_ota/pre-ota.sh; then
-    echo "Imporve OTA script"
+    echo "Improve OTA script"
     mount --bind "${sd_mountdir}/mijia-720p-hack/scripts/.pre-ota.sh" /mnt/data/miio_ota/pre-ota.sh
   fi
   #/mnt/data/imi/imi_init/S95miio_ota


### PR DESCRIPTION
Hi!

I dockerized the build as it took me a bit to build myself a working set of binaries on a mac. 
Using this dockerfile and the build.sh script I have a working webcam :) 

While my sdcard was not accepted by the camera, I noticed a few changes on the `ft_boot.sh`,  but didn't see any updates on the secret.bin. I updated secret.bin as mentioned in [Filipowicz251/mijia-1080P-hacks Wiki](https://github.com/Filipowicz251/mijia-1080P-hacks/wiki), which solved my hack-not-accepted-issues.

I have a chuangmi 720p camera and not a mijia 720p, so I wasn't able to test all functionality, but for the people that want to build the binaries themselves, this should suffice. 